### PR TITLE
Remove Google PSE

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,9 +28,9 @@
         <a href="https://github.com/amitkumar-aimlp/projects" class="btn">View on GitHub</a>
         <a href="https://github.com/amitkumar-aimlp" class="btn">About Me</a>
       {% endif %}
-      <script async src="https://cse.google.com/cse.js?cx=0282b61fa65364991">
+      <!--<script async src="https://cse.google.com/cse.js?cx=0282b61fa65364991">
       </script>
-      <div class="gcse-search"></div>
+      <div class="gcse-search"></div>-->
     </header>
 
     <main id="content" class="main-content" role="main">


### PR DESCRIPTION
As PSE works according to the Google Search Index data; Search for alternate solutions.

Reasons to drop temporarily:

- Query term color problem
- Play with css later.
